### PR TITLE
feat: Update CMake configuration and improve code structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,11 @@ project(adsil_analyzer)
 
 enable_testing()  
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Set output directory for the executable
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 # External dependencies
 find_package(OpenGL REQUIRED)
@@ -14,6 +17,10 @@ find_package(glm REQUIRED)
 # GLAD as static lib
 add_library(glad STATIC external/glad/src/glad.c)
 target_include_directories(glad PUBLIC external/glad/include)
+
+# Add custom CMake modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+include(CompilerWarnings)
 
 # Automatically add all modules
 file(GLOB MODULE_DIRS RELATIVE "${CMAKE_SOURCE_DIR}/modules" "${CMAKE_SOURCE_DIR}/modules/*")

--- a/apps/adsil_analyzer/CMakeLists.txt
+++ b/apps/adsil_analyzer/CMakeLists.txt
@@ -1,12 +1,10 @@
 file(GLOB_RECURSE APP_SOURCES "*.cpp")
 file(GLOB_RECURSE APP_HEADERS "*.hpp")
-project(adsil_analyzer)
 
-# Set output directory for the executable
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 
 add_executable(${PROJECT_NAME} ${APP_SOURCES} ${APP_HEADERS})
+
 
 # GLAD
 target_sources(${PROJECT_NAME} PRIVATE ${CMAKE_SOURCE_DIR}/external/glad/src/glad.c)

--- a/apps/adsil_analyzer/main.cpp
+++ b/apps/adsil_analyzer/main.cpp
@@ -1,9 +1,11 @@
 #include "main.hpp"
 #include <iostream>
+#include <filesystem>
 
 int main()
 {
     // adapter initializations
+    std::cout << "Current path is " << std::filesystem::current_path() << std::endl;
     adapter::AdapterManager adapters;
     auto car = adapters.fromJson<std::shared_ptr<Car>>("bin/resources/car.json");
     auto scene = adapters.fromJson<std::shared_ptr<SimulationScene>>("bin/resources/objects.json");
@@ -20,6 +22,8 @@ int main()
     // // VIEWER START
     viewer::OpenGLViewer viewer(1280, 720, "ADSIL Analyzer - OpenGL");
 
+    SharedVec<viewer::Entity> entities;
+
     auto axisEntity = std::make_shared<viewer::AxisEntity>();
     viewer.addEntity(axisEntity); // Assuming `addEntity` works on IEntity*
 
@@ -35,7 +39,18 @@ int main()
     {
         auto shapeEntity = std::make_shared<viewer::ShapeEntity>(shape);
         viewer.addEntity(shapeEntity);
+        // entities.push_back(shapeEntity);
     }
+
+    // entities.push_back(axisEntity);
+    // entities.push_back(groundEntity);
+    // entities.push_back(carEntity);
+
+    // for (auto entity : entities)
+    // {
+    //     std::cout << entity->getName() << std::endl;
+    // }
+
     std::cout << "[INFO] Entities loaded." << std::endl;
 
     viewer.run();

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,0 +1,8 @@
+# cmake/CompilerWarnings.cmake
+function(enable_compiler_warnings target)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror -Wshadow -Wconversion)
+    elseif (MSVC)
+        target_compile_options(${target} PRIVATE /W4 /WX)
+    endif()
+endfunction()

--- a/modules/Adapter/CMakeLists.txt
+++ b/modules/Adapter/CMakeLists.txt
@@ -3,6 +3,8 @@ file(GLOB_RECURSE ADAPTER_HEADERS "include/**/*.hpp")
 
 add_library(Adapter STATIC ${ADAPTER_SOURCES} ${ADAPTER_HEADERS})
 
+enable_compiler_warnings(Adapter)
+
 add_subdirectory(tests)
 
 target_include_directories(Adapter PUBLIC

--- a/modules/Adapter/src/SceneJsonAdapter.cpp
+++ b/modules/Adapter/src/SceneJsonAdapter.cpp
@@ -4,7 +4,7 @@
 namespace adapter
 {
     SceneJsonAdapter::SceneJsonAdapter()
-        : carAdapter_(), pointAdapter_(), shapeAdapter_()
+        : carAdapter_(), shapeAdapter_(), pointAdapter_()
     {
     }
 

--- a/modules/Core/CMakeLists.txt
+++ b/modules/Core/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB_RECURSE CORE_SOURCES "src/*.cpp")
 file(GLOB_RECURSE CORE_HEADERS "include/**/*.hpp")
 
 add_library(Core STATIC ${CORE_SOURCES} ${CORE_HEADERS})
+enable_compiler_warnings(Core)
 
 target_include_directories(Core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/modules/Core/include/core/Car.hpp
+++ b/modules/Core/include/core/Car.hpp
@@ -23,8 +23,8 @@ public:
     void moveForward(float step = 100.0f);
     void rotateYaw(float angleDeg);
 
-    SharedVec<Device> getTransmitters() const;
-    SharedVec<Device> getReceivers() const;
+    const SharedVec<Device> &getTransmitters() const;
+    const SharedVec<Device> &getReceivers() const;
     SharedVec<Device> getAllDevices() const;
 
     const std::vector<Point> &getTrajectory() const;

--- a/modules/Core/src/Car.cpp
+++ b/modules/Core/src/Car.cpp
@@ -37,11 +37,11 @@ Car::Car(const CarConfig &config)
     trajectory_.push_back(getPosition());
 }
 
-SharedVec<Device> Car::getTransmitters() const
+const SharedVec<Device> &Car::getTransmitters() const
 {
     return transmitters_;
 }
-SharedVec<Device> Car::getReceivers() const
+const SharedVec<Device> &Car::getReceivers() const
 {
     return receivers_;
 }

--- a/modules/Geometry/CMakeLists.txt
+++ b/modules/Geometry/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB_RECURSE GEOMETRY_SOURCES "src/*.cpp")
 file(GLOB_RECURSE GEOMETRY_HEADERS "include/**/*.hpp")
 
 add_library(Geometry STATIC ${GEOMETRY_SOURCES} ${GEOMETRY_HEADERS})
+enable_compiler_warnings(Geometry)
 
 target_include_directories(Geometry PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/modules/Geometry/include/geometry/implementations/ShapeBase.hpp
+++ b/modules/Geometry/include/geometry/implementations/ShapeBase.hpp
@@ -5,6 +5,7 @@
 #include <spatial/implementations/Transform.hpp>
 #include <spatial/implementations/HasTransformNodeBase.hpp>
 #include <geometry/interfaces/IShape.hpp>
+#include <iostream>
 
 class ShapeBase : public IShape, public spatial::HasTransformNodeBase
 {
@@ -21,7 +22,10 @@ public:
     void setOrigin(const Point &origin) { transform_.setPosition(origin); }
     void setOrientation(const Vector &orientation) { transform_.setOrientation(orientation); }
 
-    const std::string &getName() const { return name_; }
+    const std::string &getName() const
+    {
+        return name_;
+    }
     void setName(const std::string &name) { name_ = name; }
 
 protected:

--- a/modules/Geometry/src/Cube.cpp
+++ b/modules/Geometry/src/Cube.cpp
@@ -80,12 +80,12 @@ std::vector<Point> Cube::wireframe() const
 std::vector<Point> Cube::generateFace(const Vector &center, const Vector &u, const Vector &v, int n) const
 {
     std::vector<Point> points;
-    float step = dimension_ / (n - 1);
+    float step = dimension_ / static_cast<float>(n - 1);
     for (int i = 0; i < n; ++i)
     {
         for (int j = 0; j < n; ++j)
         {
-            Vector offset = u * (-dimension_ / 2 + i * step) + v * (-dimension_ / 2 + j * step);
+            Vector offset = u * (-dimension_ / 2 + static_cast<float>(i) * step) + v * (-dimension_ / 2 + static_cast<float>(j) * step);
             Vector rotated = RotationUtils::rotateRPY(center + offset, transform_.getOrientation());
             points.emplace_back(
                 transform_.getPosition().x() + rotated.x(),

--- a/modules/Geometry/src/Cylinder.cpp
+++ b/modules/Geometry/src/Cylinder.cpp
@@ -17,7 +17,9 @@ std::shared_ptr<PointCloud> Cylinder::surfaceMesh(int quality) const
     {
         for (int i = 0; i < circRes; ++i)
         {
-            float angle = 2 * M_PI * i / circRes;
+            constexpr float PI = static_cast<float>(M_PI);
+            float angle = 2.0f * PI * static_cast<float>(i) / static_cast<float>(circRes);
+
             Vector local(cylinderDimension.radius_ * std::cos(angle), cylinderDimension.radius_ * std::sin(angle), z);
             Vector rotated = RotationUtils::rotateRPY(local, transform_.getOrientation());
             cloud->addPoint(Point(
@@ -30,13 +32,15 @@ std::shared_ptr<PointCloud> Cylinder::surfaceMesh(int quality) const
     // Side surface
     for (int i = 0; i < circRes; ++i)
     {
-        float angle = 2 * M_PI * i / circRes;
+        constexpr float PI = static_cast<float>(M_PI);
+        float angle = 2.0f * PI * static_cast<float>(i) / static_cast<float>(circRes);
+
         Vector base(cylinderDimension.radius_ * std::cos(angle), cylinderDimension.radius_ * std::sin(angle), -halfHeight);
         Vector top(cylinderDimension.radius_ * std::cos(angle), cylinderDimension.radius_ * std::sin(angle), +halfHeight);
 
         for (int j = 0; j < heightRes; ++j)
         {
-            float t = static_cast<float>(j) / (heightRes - 1);
+            float t = static_cast<float>(j) / static_cast<float>(heightRes - 1);
             Vector local = base + (top - base) * t;
             Vector rotated = RotationUtils::rotateRPY(local, transform_.getOrientation());
             cloud->addPoint(Point(
@@ -54,14 +58,15 @@ std::vector<Point> Cylinder::wireframe() const
     std::vector<Point> framePoints;
 
     int segments = 16;
-    float angleStep = 2 * M_PI / segments;
+    constexpr float PI = static_cast<float>(M_PI);
+    float angleStep = 2.0f * PI / static_cast<float>(segments);
     float halfHeight = cylinderDimension.height_ / 2.0f;
 
     for (int i = 0; i < segments; ++i)
     {
-        float angle = i * angleStep;
-        float x = cylinderDimension.radius_ * cos(angle);
-        float y = cylinderDimension.radius_ * sin(angle);
+        float angle = static_cast<float>(i) * angleStep;
+        float x = cylinderDimension.radius_ * cosf(angle);
+        float y = cylinderDimension.radius_ * sinf(angle);
 
         Vector bottomLocal(x, y, -halfHeight);
         Vector topLocal(x, y, +halfHeight);

--- a/modules/Geometry/src/Device.cpp
+++ b/modules/Geometry/src/Device.cpp
@@ -25,7 +25,7 @@ std::shared_ptr<PointCloud> Device::pointsInFov(const PointCloud &pcd) const
 
         float horizontal_d_angle = std::atan2(transformNode_->getLocalTransform().get3DDirectionVector().y(), transformNode_->getLocalTransform().get3DDirectionVector().x());
         float vertical_d_angle = std::atan2(transformNode_->getLocalTransform().get3DDirectionVector().y(), transformNode_->getLocalTransform().get3DDirectionVector().z());
-        float epsilon = 1e-7;
+        float epsilon = static_cast<float>(1e-7);
         if ((std::abs(horizontal_p_angle - horizontal_d_angle) - (horizontal_fov_rad_ / 2.0f)) < epsilon &&
             (std::abs(vertical_p_angle - vertical_d_angle) - (vertical_fov_rad_ / 2.0f)) < epsilon)
         {

--- a/modules/Simulation/CMakeLists.txt
+++ b/modules/Simulation/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB_RECURSE SIMULATION_SOURCES "src/*.cpp")
 file(GLOB_RECURSE SIMULATION_HEADERS "include/**/*.hpp")
 
 add_library(Simulation STATIC ${SIMULATION_SOURCES} ${SIMULATION_HEADERS})
+enable_compiler_warnings(Simulation)
 
 target_include_directories(Simulation PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/modules/Spatial/CMakeLists.txt
+++ b/modules/Spatial/CMakeLists.txt
@@ -4,6 +4,7 @@ file(GLOB_RECURSE SPATIAL_HEADERS "include/**/*.hpp")
 
 # Create static library
 add_library(Spatial STATIC ${SPATIAL_SOURCES} ${SPATIAL_HEADERS})
+enable_compiler_warnings(Spatial)
 
 # Public headers for consumers of Spatial
 target_include_directories(Spatial

--- a/modules/Spatial/src/Transform.cpp
+++ b/modules/Spatial/src/Transform.cpp
@@ -55,17 +55,17 @@ const Vector Transform::get3DDirectionVector() const
     float sYaw = std::sin(yaw);
 
     // Dönüş matrisi elemanları (Z-Y-X sırayla Euler açılarından)
-    float m00 = cYaw * cPitch;
+    // float m00 = cYaw * cPitch;
     float m01 = cYaw * sPitch * sRoll - sYaw * cRoll;
-    float m02 = cYaw * sPitch * cRoll + sYaw * sRoll;
+    // float m02 = cYaw * sPitch * cRoll + sYaw * sRoll;
 
-    float m10 = sYaw * cPitch;
+    // float m10 = sYaw * cPitch;
     float m11 = sYaw * sPitch * sRoll + cYaw * cRoll;
-    float m12 = sYaw * sPitch * cRoll - cYaw * sRoll;
+    // float m12 = sYaw * sPitch * cRoll - cYaw * sRoll;
 
-    float m20 = -sPitch;
+    // float m20 = -sPitch;
     float m21 = cPitch * sRoll;
-    float m22 = cPitch * cRoll;
+    // float m22 = cPitch * cRoll;
 
     // İleri yön vektörü lokal (0, 1, 0)
     // Dünya koordinatlarına dönüşüm:

--- a/modules/Spatial/src/TransformNode.cpp
+++ b/modules/Spatial/src/TransformNode.cpp
@@ -6,11 +6,11 @@ namespace spatial
 
     // Constructor: default local transform (identity)
     TransformNode::TransformNode()
-        : localTransform_(Transform()), dirty_(true) {}
+        : cachedGlobalTransform_(), dirty_(true), localTransform_(Transform()) {}
 
     // Constructor: initialize with given local transform
     TransformNode::TransformNode(const Transform &localTransform)
-        : localTransform_(localTransform), dirty_(true)
+        : cachedGlobalTransform_(), dirty_(true), localTransform_(localTransform)
     {
         // std::cout << localTransform_.get3DDirectionVector().toString() << std::endl;
     }

--- a/modules/Utils/CMakeLists.txt
+++ b/modules/Utils/CMakeLists.txt
@@ -2,6 +2,7 @@ file(GLOB_RECURSE UTILS_SOURCES "src/*.cpp")
 file(GLOB_RECURSE UTILS_HEADERS "include/**/*.hpp")
 
 add_library(Utils STATIC ${UTILS_SOURCES} ${UTILS_HEADERS})
+enable_compiler_warnings(Utils)
 
 target_include_directories(Utils PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/modules/Viewer/CMakeLists.txt
+++ b/modules/Viewer/CMakeLists.txt
@@ -19,17 +19,29 @@ set(IMGUI_SOURCES
 set(TINYOBJLOADER_SRC ${CMAKE_SOURCE_DIR}/external/tinyobjloader/tiny_obj_loader.cc)
 
 
-# Create static library
-add_library(Viewer STATIC ${VIEWER_SOURCES} ${VIEWER_HEADERS} ${IMGUI_SOURCES} ${TINYOBJLOADER_SRC})
+# Create static library from Viewer-only sources
+add_library(Viewer STATIC ${VIEWER_SOURCES} ${VIEWER_HEADERS})
+
+# Add ImGui and TinyObjLoader sources separately
+target_sources(Viewer PRIVATE ${IMGUI_SOURCES} ${TINYOBJLOADER_SRC})
+
+# Disable warnings for ImGui and TinyObjLoader sources
+foreach(source_file IN LISTS IMGUI_SOURCES)
+    set_source_files_properties(${source_file} PROPERTIES COMPILE_FLAGS "-w")
+endforeach()
+set_source_files_properties(${TINYOBJLOADER_SRC} PROPERTIES COMPILE_FLAGS "-w")
+
+# Enable warnings for Viewer sources
+enable_compiler_warnings(Viewer)
 
 # Public headers for consumers of Viewer
 target_include_directories(Viewer
-    PUBLIC  ${CMAKE_CURRENT_SOURCE_DIR}/include
-            ${IMGUI_DIR}
-            ${IMGUI_DIR}/backends
-            ${CMAKE_SOURCE_DIR}/external/tinyobjloader  
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${IMGUI_DIR}
+        ${IMGUI_DIR}/backends
+        ${CMAKE_SOURCE_DIR}/external/tinyobjloader  
 )
-
 
 # Link internal dependencies and external libraries
 target_link_libraries(Viewer

--- a/modules/Viewer/include/viewer/entities/Entity.hpp
+++ b/modules/Viewer/include/viewer/entities/Entity.hpp
@@ -1,18 +1,22 @@
 #pragma once
 #include <viewer/interfaces/IEntity.hpp>
 
-class Entity : public IEntity
+namespace viewer
 {
-public:
-    virtual ~Entity() = default;
+    class Entity : public IEntity
+    {
+    public:
+        virtual ~Entity() = default;
 
-    void setVisible(bool visible) override { visible_ = visible; }
-    bool isVisible() const override { return visible_; }
+        void setVisible(bool visible) override { visible_ = visible; }
+        bool isVisible() const override { return visible_; }
 
-    // Provide default fallback behavior
-    bool isTransparent() const override { return false; }
-    glm::vec3 getCenter() const override { return glm::vec3(0.0f); }
+        // Provide default fallback behavior
+        bool isTransparent() const override { return false; }
+        glm::vec3 getCenter() const override { return glm::vec3(0.0f); }
 
-protected:
-    bool visible_ = true;
-};
+    protected:
+        bool visible_ = true;
+    };
+
+}

--- a/modules/Viewer/include/viewer/entities/ShapeEntity.hpp
+++ b/modules/Viewer/include/viewer/entities/ShapeEntity.hpp
@@ -13,7 +13,7 @@ namespace viewer
     class ShapeEntity : public Entity
     {
     public:
-        ShapeEntity(std::shared_ptr<ShapeBase> shape, const std::string &name = "UnnamedShape", const glm::vec3 &color = glm::vec3(0.6f, 0.6f, 0.9f));
+        ShapeEntity(std::shared_ptr<ShapeBase> shape, const glm::vec3 &color = glm::vec3(0.6f, 0.6f, 0.9f));
 
         void initGL() override;
         void render(const glm::mat4 &view, const glm::mat4 &projection) override;
@@ -27,7 +27,6 @@ namespace viewer
     private:
         std::shared_ptr<ShapeBase> shape_;
         std::shared_ptr<ShapeRenderable> shapeRenderable_;
-        std::string name_;
         glm::vec3 color_;
     };
 

--- a/modules/Viewer/include/viewer/entities/entities.hpp
+++ b/modules/Viewer/include/viewer/entities/entities.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Entity.hpp"
 #include "DeviceEntity.hpp"
 #include "CarEntity.hpp"
 #include "GroundEntity.hpp"

--- a/modules/Viewer/include/viewer/implementations/GroundRenderable.hpp
+++ b/modules/Viewer/include/viewer/implementations/GroundRenderable.hpp
@@ -19,7 +19,7 @@ namespace viewer
 
     private:
         std::shared_ptr<spatial::HasTransformNodeBase> transformNode_;
-        int vertexCount_{0};
+        size_t vertexCount_{0};
 
     protected:
         void createShader() override;

--- a/modules/Viewer/include/viewer/implementations/OpenGLViewer.hpp
+++ b/modules/Viewer/include/viewer/implementations/OpenGLViewer.hpp
@@ -53,18 +53,15 @@ namespace viewer
         int width_;
         int height_;
         std::string title_;
-        RenderingMode renderingMode_;
-
-        ImGuiLayer imguiLayer_;
         Camera camera_;
         float lastX_;
         float lastY_;
         bool firstMouse_;
         bool rightMousePressed_;
-
         float deltaTime_;
         float lastFrame_;
-
+        RenderingMode renderingMode_;
+        ImGuiLayer imguiLayer_;
         int displayedFPS_ = 0;
 
         SharedVec<Renderable> renderables_;

--- a/modules/Viewer/include/viewer/implementations/PointCloudRenderable.hpp
+++ b/modules/Viewer/include/viewer/implementations/PointCloudRenderable.hpp
@@ -22,8 +22,8 @@ namespace viewer
 
     private:
         std::shared_ptr<PointCloud> pointCloud_;
-        glm::vec3 color_{1.0f, 1.0f, 1.0f}; // default white
         bool visible_{true};
+        glm::vec3 color_{1.0f, 1.0f, 1.0f}; // default white
 
     protected:
         void createShader() override;

--- a/modules/Viewer/include/viewer/interfaces/IEntity.hpp
+++ b/modules/Viewer/include/viewer/interfaces/IEntity.hpp
@@ -3,26 +3,29 @@
 #include <glm/glm.hpp>
 #include <string>
 
-class IEntity
+namespace viewer
 {
-public:
-    virtual ~IEntity() = default;
+    class IEntity
+    {
+    public:
+        virtual ~IEntity() = default;
 
-    virtual void initGL() = 0;
-    virtual void render(const glm::mat4 &view, const glm::mat4 &projection) = 0;
-    virtual void cleanup() = 0;
+        virtual void initGL() = 0;
+        virtual void render(const glm::mat4 &view, const glm::mat4 &projection) = 0;
+        virtual void cleanup() = 0;
 
-    virtual bool isVisible() const = 0;
-    virtual void setVisible(bool visible) = 0;
+        virtual bool isVisible() const = 0;
+        virtual void setVisible(bool visible) = 0;
 
-    virtual void update(float deltaTime) {} // default no-op
+        virtual void update(float) {} // default no-op
 
-    virtual glm::vec3 getColor() const { return glm::vec3(1.0f); } // default white
+        virtual glm::vec3 getColor() const { return glm::vec3(1.0f); } // default white
 
-    virtual bool isTransparent() const = 0;
+        virtual bool isTransparent() const = 0;
 
-    virtual glm::vec3 getCenter() const = 0;
+        virtual glm::vec3 getCenter() const = 0;
 
-    // Optional: for debug, scene selection, etc.
-    virtual std::string getName() const = 0;
-};
+        // Optional: for debug, scene selection, etc.
+        virtual std::string getName() const = 0;
+    };
+}

--- a/modules/Viewer/src/Camera.cpp
+++ b/modules/Viewer/src/Camera.cpp
@@ -67,9 +67,9 @@ void Camera::processMouseScroll(float yoffset)
 void Camera::updateCameraVectors()
 {
     glm::vec3 front;
-    front.x = cos(glm::radians(yaw_)) * cos(glm::radians(pitch_));
-    front.y = sin(glm::radians(pitch_));
-    front.z = sin(glm::radians(yaw_)) * cos(glm::radians(pitch_));
+    front.x = cosf(glm::radians(yaw_)) * cosf(glm::radians(pitch_));
+    front.y = sinf(glm::radians(pitch_));
+    front.z = sinf(glm::radians(yaw_)) * cosf(glm::radians(pitch_));
     front_ = glm::normalize(front);
     right_ = glm::normalize(glm::cross(front_, worldUp_));
     up_ = glm::normalize(glm::cross(right_, front_));

--- a/modules/Viewer/src/FovPyramidRenderable.cpp
+++ b/modules/Viewer/src/FovPyramidRenderable.cpp
@@ -116,8 +116,8 @@ namespace viewer
         float fovV = device_->getVerticalFovRad();
         float range = device_->getRange();
 
-        float halfW = range * tan(fovH / 2.0f);
-        float halfH = range * tan(fovV / 2.0f);
+        float halfW = range * tanf(fovH / 2.0f);
+        float halfH = range * tanf(fovV / 2.0f);
 
         glm::vec3 apex(0.0f, 0.0f, 0.0f);
         glm::vec3 v1(-halfW, halfH, range);

--- a/modules/Viewer/src/GroundRenderable.cpp
+++ b/modules/Viewer/src/GroundRenderable.cpp
@@ -108,7 +108,7 @@ namespace viewer
         glUniformMatrix4fv(projLoc, 1, GL_FALSE, glm::value_ptr(projection));
 
         glBindVertexArray(vao_);
-        glDrawArrays(GL_LINES, 0, vertexCount_);
+        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(vertexCount_));
         glBindVertexArray(0);
     }
 

--- a/modules/Viewer/src/OpenGLViewer.cpp
+++ b/modules/Viewer/src/OpenGLViewer.cpp
@@ -6,15 +6,21 @@
 namespace viewer
 {
     OpenGLViewer::OpenGLViewer(int width, int height, const std::string &title)
-        : width_(width), height_(height), title_(title), window_(nullptr), camera_(
+        : window_(nullptr), width_(width), height_(height), title_(title), camera_(
                                                                                glm::vec3(0.0f, 20.0f, 5.0f), // position
                                                                                glm::vec3(0.0f, 1.0f, 0.0f),  // up direction
                                                                                90.0f,                        // yaw (looking toward -Z)
                                                                                -89.0f                        // pitch
                                                                                ),
-          lastX_(width / 2.0f), lastY_(height / 2.0f),
+          lastX_(static_cast<float>(width) / 2.0f), lastY_(static_cast<float>(height) / 2.0f),
           firstMouse_(true), rightMousePressed_(false),
-          deltaTime_(0.0f), lastFrame_(0.0f), renderingMode_(viewer::RenderingMode::Perspective)
+          deltaTime_(0.0f), lastFrame_(0.0f),
+          renderingMode_(viewer::RenderingMode::Perspective),
+          imguiLayer_(),    // ✅ açıkça ekle
+          displayedFPS_(0), // ✅ tekrar ekle (netlik için)
+          renderables_(),   // ✅ boş başlat
+          entities_()       // ✅ boş başlat
+
     {
     }
 
@@ -66,7 +72,7 @@ namespace viewer
 
     void OpenGLViewer::updateDeltaTime()
     {
-        float currentFrame = glfwGetTime();
+        float currentFrame = static_cast<float>(glfwGetTime());
         deltaTime_ = currentFrame - lastFrame_;
         lastFrame_ = currentFrame;
     }
@@ -98,15 +104,15 @@ namespace viewer
 
         if (viewer->firstMouse_)
         {
-            viewer->lastX_ = xpos;
-            viewer->lastY_ = ypos;
+            viewer->lastX_ = static_cast<float>(xpos);
+            viewer->lastY_ = static_cast<float>(ypos);
             viewer->firstMouse_ = false;
         }
 
-        float xoffset = xpos - viewer->lastX_;
-        float yoffset = viewer->lastY_ - ypos;
-        viewer->lastX_ = xpos;
-        viewer->lastY_ = ypos;
+        float xoffset = static_cast<float>(xpos) - viewer->lastX_;
+        float yoffset = viewer->lastY_ - static_cast<float>(ypos);
+        viewer->lastX_ = static_cast<float>(xpos);
+        viewer->lastY_ = static_cast<float>(ypos);
 
         viewer->camera_.processMouseMovement(xoffset, yoffset); });
 
@@ -129,7 +135,7 @@ namespace viewer
         glfwSetScrollCallback(window_, [](GLFWwindow *win, double, double yoffset)
                               {
         auto *viewer = static_cast<OpenGLViewer *>(glfwGetWindowUserPointer(win));
-        viewer->camera_.processMouseScroll(yoffset); });
+        viewer->camera_.processMouseScroll(static_cast<float>(yoffset)); });
     }
 
     void OpenGLViewer::setRenderingMode(RenderingMode mode)
@@ -184,7 +190,7 @@ namespace viewer
 
     glm::mat4 OpenGLViewer::getProjectionMatrix() const
     {
-        float aspect = static_cast<float>(width_) / height_;
+        float aspect = static_cast<float>(width_) / static_cast<float>(height_);
         if (renderingMode_ == RenderingMode::Perspective)
         {
             return glm::perspective(glm::radians(camera_.getFov()), aspect, 0.1f, 1000.0f);

--- a/modules/Viewer/src/ShapeRenderable.cpp
+++ b/modules/Viewer/src/ShapeRenderable.cpp
@@ -123,7 +123,7 @@ namespace viewer
         glUniform3fv(uniforms_.uniformColor, 1, &color_[0]);
 
         glBindVertexArray(vao_);
-        glDrawArrays(GL_POINTS, 0, vertexCount_);
+        glDrawArrays(GL_POINTS, 0, static_cast<GLsizei>(vertexCount_));
         glBindVertexArray(0);
     }
 

--- a/modules/Viewer/src/entitites/ShapeEntity.cpp
+++ b/modules/Viewer/src/entitites/ShapeEntity.cpp
@@ -4,16 +4,12 @@
 namespace viewer
 {
 
-    ShapeEntity::ShapeEntity(std::shared_ptr<ShapeBase> shape, const std::string &name, const glm::vec3 &color)
-        : shape_(std::move(shape)), name_(name), color_(color)
+    ShapeEntity::ShapeEntity(std::shared_ptr<ShapeBase> shape, const glm::vec3 &color) : shape_(shape), color_(color)
     {
-        std::cout << "[DEBUG] ShapeEntity '" << name_ << "' created." << std::endl;
     }
 
     void ShapeEntity::initGL()
     {
-        std::cout << "[DEBUG] ShapeEntity::initGL() for " << name_ << std::endl;
-
         shapeRenderable_ = std::make_unique<ShapeRenderable>(shape_, color_);
         shapeRenderable_->initGL(); // likely crash happens here
     }
@@ -49,7 +45,7 @@ namespace viewer
 
     std::string ShapeEntity::getName() const
     {
-        return name_;
+        return shape_->getName();
     }
 
 }


### PR DESCRIPTION
- Set C++ standard to C++20 in CMakeLists.txt
- Organize output directory for executables
- Add custom CMake module for enabling compiler warnings
- Refactor Viewer module to separate ImGui and TinyObjLoader sources
- Enhance various classes with better type safety and code clarity
- Introduce filesystem support in main.cpp for current path logging