### PR TITLE
Add FPS control and integrate with playback speed slider

### DIFF
--- a/modules/Simulation/include/simulation/implementations/FrameBufferManager.hpp
+++ b/modules/Simulation/include/simulation/implementations/FrameBufferManager.hpp
@@ -26,6 +26,8 @@ namespace simulation
         void seek(int frameId);
         void stepForward();
         void stepBackward();
+        void setFPS(float fps) { frameInterval_ = 1.0f / fps; }
+        float getFPS() const { return 1.0f / frameInterval_; }
 
         void advanceFrame(int direction);
         void shiftWindow(int direction);

--- a/modules/Viewer/include/viewer/imgui/FrameManagerInspectorPanel.hpp
+++ b/modules/Viewer/include/viewer/imgui/FrameManagerInspectorPanel.hpp
@@ -18,7 +18,5 @@ namespace viewer::imgui
         void drawJumpToFrame(const std::shared_ptr<simulation::FrameBufferManager> &frameBuffer);
 
         int jumpTarget_ = 0;
-
-        float playbackSpeed_ = 1.0f; // frames per second
     };
 }

--- a/modules/Viewer/src/panels/FrameManagerInspectorPanel.cpp
+++ b/modules/Viewer/src/panels/FrameManagerInspectorPanel.cpp
@@ -58,7 +58,11 @@ namespace viewer::imgui
         }
         ImGui::SameLine();
 
-        ImGui::SliderFloat("Speed (fps)", &playbackSpeed_, 0.1f, 60.0f, "%.1f");
+        static float playbackSpeed_ = frameBuffer->getFPS();
+        if (ImGui::SliderFloat("Speed (fps)", &playbackSpeed_, 0.1f, 60.0f, "%.1f"))
+        {
+            frameBuffer->setFPS(playbackSpeed_);
+        }
     }
 
     void FrameManagerInspectorPanel::drawJumpToFrame(const std::shared_ptr<simulation::FrameBufferManager> &frameBuffer)


### PR DESCRIPTION
Introduce FPS control in the FrameBufferManager and connect it to the playback speed slider in the FrameManagerInspectorPanel for enhanced playback functionality.