### PR TITLE
Add binary distribution support and installation instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.15)
-project(adsil_analyzer)
+project(adsil_analyzer VERSION 0.1.0)
 
 enable_testing()  
 
@@ -35,4 +35,48 @@ foreach(app_dir ${APP_DIRS})
         add_subdirectory("apps/${app_dir}")
     endif()
 endforeach()
+
+# ------------------------
+# Distribution / Packaging
+# ------------------------
+option(ADSIL_DISTRIBUTION "Build optimized, stripped distribution binary" OFF)
+
+if(ADSIL_DISTRIBUTION)
+    # Force Release
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+        message(STATUS "Forcing Release build for distribution")
+        set(CMAKE_BUILD_TYPE Release CACHE STRING "" FORCE)
+    endif()
+    add_compile_options(-O3 -DNDEBUG -fvisibility=hidden)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -s")
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT ipo_supported OUTPUT ipo_error)
+    if(ipo_supported)
+        message(STATUS "IPO/LTO enabled for distribution build")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
+    else()
+        message(WARNING "IPO/LTO not supported: ${ipo_error}")
+    endif()
+endif()
+
+# Install resources (exclude volatile/log folders)
+install(DIRECTORY resources/ DESTINATION resources
+    PATTERN "logs" EXCLUDE
+    PATTERN "logs/*" EXCLUDE
+    PATTERN "extracted_frames_json" EXCLUDE
+    PATTERN "extracted_frames_json/*" EXCLUDE)
+
+# Wrapper run script (no substitution needed) installed at package root
+install(PROGRAMS ${CMAKE_SOURCE_DIR}/cmake/run_adsil.sh.in DESTINATION . RENAME run_adsil.sh)
+
+# CPack configuration (binary-only package)
+set(CPACK_PACKAGE_NAME "adsil_analyzer")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_VENDOR "rekrom")
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-linux-x86_64")
+set(CPACK_STRIP_FILES TRUE)
+set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+set(CPACK_PACKAGE_CONTACT "")
+include(CPack)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,35 @@ cmake .. -DBUILD_TESTING=ON
 ctest --output-on-failure
 ```
 
+### Binary Distribution (No Source Code)
+
+To produce a tar.gz package containing only the stripped executable and resources (no source code):
+
+```bash
+mkdir -p build && cd build
+cmake .. -DADSIL_DISTRIBUTION=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build . --parallel
+cpack  # generates adsil_analyzer-<version>-linux-x86_64.tar.gz
+```
+
+The archive layout:
+
+```
+bin/adsil_analyzer
+resources/...
+run_adsil.sh
+```
+
+Users run:
+
+```bash
+tar xf adsil_analyzer-<version>-linux-x86_64.tar.gz
+cd adsil_analyzer
+./run_adsil.sh
+```
+
+Environment variable `ADSIL_RESOURCE_DIR` is exported by the wrapper for runtime resource loading.
+
 ---
 
 ## 🧩 Module Overview

--- a/apps/adsil_analyzer/CMakeLists.txt
+++ b/apps/adsil_analyzer/CMakeLists.txt
@@ -32,6 +32,9 @@ target_link_libraries(${PROJECT_NAME}
         Vehicle
 )
 
+# Install the main executable when packaging
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
+
 # add_custom_command(
 #     TARGET ${PROJECT_NAME} POST_BUILD
 #     COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/cmake/run_adsil.sh.in
+++ b/cmake/run_adsil.sh.in
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Wrapper script for running adsil_analyzer from an extracted distribution
+# Resolves path relative to script location for portable use.
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}"
+BIN="${ROOT_DIR}/bin/adsil_analyzer"
+RESOURCES_DIR="${ROOT_DIR}/resources"
+if [ ! -x "$BIN" ]; then
+  echo "Error: adsil_analyzer binary not found at $BIN" >&2
+  exit 1
+fi
+# Export base resource directory (app can read)
+export ADSIL_RESOURCE_DIR="${RESOURCES_DIR}"
+exec "$BIN" "$@"


### PR DESCRIPTION
Introduce support for creating a binary distribution of the application, including installation instructions and a wrapper script for execution. This enhancement allows users to build and run the application without needing the source code.